### PR TITLE
Use a streaming version for reading the input file

### DIFF
--- a/playingwithprojections.cabal
+++ b/playingwithprojections.cabal
@@ -44,6 +44,10 @@ library
     , base >=4.7 && <5
     , containers
     , flow
+    , json-stream
+    , streaming
+    , streaming-bytestring
+    , streaming-utils
     , time
     , unordered-containers
   default-language: Haskell2010

--- a/stack.yaml
+++ b/stack.yaml
@@ -39,7 +39,9 @@ packages:
 # - git: https://github.com/commercialhaskell/stack.git
 #   commit: e7b331f14bcffb8367cd58fbfc8b40ec7642100a
 #
-# extra-deps: []
+extra-deps:
+  - json-stream-0.4.2.4@sha256:8b7f17d54a6e1e6311756270f8bcf51e91bab4300945400de66118470dcf51b9,4716
+  - streaming-utils-0.2.0.0@sha256:a2bd9144b336393122ffed2d3a1c747c186b8fdb9734c54d8b5874ed6166a85b,4114
 
 # Override default flag values for local packages and extra-deps
 # flags: {}


### PR DESCRIPTION
On my machine, consuming the large input file with the naive implementation of the event store takes around 18GB of memory before the app gets OOM killed. I managed to slightly improve it by using `decodeFileStrict'` instead of `decodeFileStrict`, but it still was way too much even for an input file of this size and wasn't sufficient to avoid running out of memory.

I went ahead and implemented a streaming version using [streaming](https://hackage.haskell.org/package/streaming) and [json-stream](http://hackage.haskell.org/package/json-stream). I'm not entirely sure how to measure it, but if I read `htop` correctly, the app needs less than 100MB memory for the large input file.
Also, it runs significantly faster compared to the previous version.

Since the input file is read incrementally there's no way to validate the JSON before consuming it, but I guess this is okay for this kind of project.